### PR TITLE
Fixed DM failure bug

### DIFF
--- a/stalkbroker/bot/_commands_settings.py
+++ b/stalkbroker/bot/_commands_settings.py
@@ -29,7 +29,7 @@ async def set_user_timezone(ctx: discord.ext.commands.Context, zone_arg: str) ->
         raise errors.BadTimezoneError(ctx, zone_arg)
     else:
         # Otherwise update the timezone then send a confirmation.
-        await STALKBROKER.db.update_timezone(ctx.author.id, ctx.guild.id, converted_tz)
+        await STALKBROKER.db.update_timezone(ctx.author, ctx.guild, converted_tz)
         await ctx.send(messages.confirmation_timezone(ctx.author, converted_tz))
 
 
@@ -44,5 +44,5 @@ async def set_bulletins_channel(ctx: discord.ext.commands.Context) -> None:
     :param ctx: message context passed in by discord.py. The channel on this context
         is used as the bulletin channel.
     """
-    await STALKBROKER.db.server_set_bulletin_channel(ctx.guild.id, ctx.channel.id)
+    await STALKBROKER.db.server_set_bulletin_channel(ctx.guild, ctx.channel)
     await ctx.send(messages.confirmation_bulletins_channel(ctx.author))

--- a/stalkbroker/bot/_events.py
+++ b/stalkbroker/bot/_events.py
@@ -32,14 +32,14 @@ async def _add_all_guild_members(guild: discord.Guild) -> None:
 
     user: discord.Member
     for member in guild.members:
-        user_coros.append(STALKBROKER.db.add_user(member.id, guild.id))
+        user_coros.append(STALKBROKER.db.add_user(member, guild))
 
     await asyncio.gather(*user_coros)
 
 
 async def _add_guild(guild: discord.Guild) -> None:
     """Add a single guild and it's users to stalkbroker's database."""
-    guild_add_coro = STALKBROKER.db.add_server(guild.id)
+    guild_add_coro = STALKBROKER.db.add_server(guild)
     member_add_coro = _add_all_guild_members(guild)
 
     await asyncio.gather(guild_add_coro, member_add_coro)
@@ -72,4 +72,4 @@ async def on_guild_join(guild: discord.Guild) -> None:
 @STALKBROKER.event
 async def on_member_join(member: discord.Member) -> None:
     """Add any new members that join."""
-    await STALKBROKER.db.add_user(member.id, member.guild.id)
+    await STALKBROKER.db.add_user(member, member.guild)

--- a/stalkbroker/errors/_handle.py
+++ b/stalkbroker/errors/_handle.py
@@ -2,9 +2,18 @@ import traceback
 import discord.ext.commands
 import logging
 import asyncio
-from typing import List, Coroutine
+from typing import List, Coroutine, Union, Type
 
 from stalkbroker import errors, messages
+
+
+def _is_general_exception(error: Union[BaseException, Type[BaseException]]) -> bool:
+    if isinstance(error, BaseException):
+        return True
+    elif isinstance(error, type) and issubclass(error, BaseException):
+        return True
+    else:
+        return False
 
 
 async def _handle_bulk_error(
@@ -27,7 +36,7 @@ async def _handle_bulk_error(
 
     # We'll raise the first error we come across.
     for result in results:
-        if isinstance(result, BaseException) or issubclass(result, BaseException):
+        if _is_general_exception(error):
             raise result
 
 

--- a/zdevelop/tests/test_integration.py
+++ b/zdevelop/tests/test_integration.py
@@ -237,7 +237,7 @@ class TestLifecycle:
         """
         Tests that the timezone got updated correctly in the last test.
         """
-        user = await stalkdb.fetch_user(test_client.user.id, test_client.guild.id)
+        user = await stalkdb.fetch_user(test_client.user, test_client.guild)
         assert user.timezone == local_tz
 
     @mark_test
@@ -265,7 +265,7 @@ class TestLifecycle:
         Tests that the bulletin channel got correctly updated.
         """
 
-        server = await stalkdb.fetch_server(test_client.guild.id)
+        server = await stalkdb.fetch_server(test_client.guild)
         assert server.bulletin_channel == test_client.channel_bulletin.id
 
     @pytest.mark.parametrize("phase_index", range(13))
@@ -376,7 +376,7 @@ class TestLifecycle:
         database.
         """
 
-        stalk_user = await stalkdb.fetch_user(test_client.user.id, test_client.guild.id)
+        stalk_user = await stalkdb.fetch_user(test_client.user, test_client.guild)
         stored_ticker = await stalkdb.fetch_ticker(stalk_user, expected_ticker.week_of)
 
         expected_ticker.user_id = stalk_user.id
@@ -505,7 +505,7 @@ class TestLifecycle:
                 expected_confirmation, expected_channel=test_client.channel_send,
             )
 
-        stalk_user = await stalkdb.fetch_user(test_client.user.id, test_client.guild.id)
+        stalk_user = await stalkdb.fetch_user(test_client.user, test_client.guild)
         ticker_set = await stalkdb.fetch_ticker(
             stalk_user, expected_ticker_week2.week_of
         )
@@ -577,7 +577,7 @@ class TestLifecycle:
                 expected_confirmation, expected_channel=test_client.channel_send,
             )
 
-        stalk_user = await stalkdb.fetch_user(test_client.user.id, test_client.guild.id)
+        stalk_user = await stalkdb.fetch_user(test_client.user, test_client.guild)
         ticker_set = await stalkdb.fetch_ticker(
             stalk_user, expected_ticker_week2.week_of
         )

--- a/zdocs/source/index.rst
+++ b/zdocs/source/index.rst
@@ -84,6 +84,15 @@ And the following bulletin will be sent to your server's bulletin channel:
     We're smart enough to know that Sunday is the day Daisey Mae comes into town. Your
     price that day will be set as the purchase price automatically!
 
+.. note::
+
+    If you are a member of multiple servers that stalkbroker is also a member of,
+    your bulletin will be sent to each server's bulletins channel. That way you only
+    need to type your update once and stalkbroker will take care of the rest.
+
+    Stalkbroker CANNOT see servers it is not invited to, so only servers which have
+    stalkbroker installed will get these automatic updates!
+
 Setting a Past Turnip Price
 ---------------------------
 


### PR DESCRIPTION
Because we add new guilds we find a user on when executing their commands, DM's were failing from lack of guild information.

Now we check to see if there is any guild info on a context before trying to add a Guild ID to the user's record.

Closes #1 