### PR TITLE
fixed some hour comparison logic for determining time of day

### DIFF
--- a/stalkbroker/date_utils/functions.py
+++ b/stalkbroker/date_utils/functions.py
@@ -168,8 +168,8 @@ def is_price_period(
         # g2g
         return local_dt.hour < 12
     else:
-        # And finally if we are checking of PM, see if it is after 12:00
-        return local_dt.hour > 12
+        # And finally if we are checking of PM, see if it is after or at 12:00
+        return local_dt.hour >= 12
 
 
 def previous_sunday(anchor_date: datetime.date) -> datetime.date:
@@ -235,7 +235,7 @@ def _deduce_price_time_of_day(
 
     msg_time = get_context_local_dt(ctx, user_tz)
 
-    if msg_time.hour <= 12:
+    if msg_time.hour < 12:
         return models.TimeOfDay.AM
     else:
         return models.TimeOfDay.PM

--- a/zdevelop/tests/conftest.py
+++ b/zdevelop/tests/conftest.py
@@ -185,7 +185,7 @@ def phase_dates(base_sunday: datetime.date) -> List[datetime.datetime]:
     )
 
     wednesday_am = relative_message_time(sunday=base_sunday, weekday=2, hour=9)
-    wednesday_pm = relative_message_time(sunday=base_sunday, weekday=2, hour=16)
+    wednesday_pm = relative_message_time(sunday=base_sunday, weekday=2, hour=12)
 
     thursday_am = relative_message_time(sunday=base_sunday, weekday=3, hour=11)
     thursday_pm = relative_message_time(sunday=base_sunday, weekday=3, hour=16)


### PR DESCRIPTION
Closes #15 

Caught a few dumb logic errors:

- It is PM if the hour is *>=* 12, not just > 12
- It is AM if the hour *<* 12 not *<=*

Whoops